### PR TITLE
Fix except syntax issue in Python 3

### DIFF
--- a/rainbowsaddle/__init__.py
+++ b/rainbowsaddle/__init__.py
@@ -103,8 +103,7 @@ class RainbowSaddle(object):
         """
         try:
             os.waitpid(pid, 0)
-        except OSError:
-            _, err, _ = sys.exc_info()
+        except OSError as err:
             if err.errno == 10:
                 while True:
                     try:

--- a/rainbowsaddle/__init__.py
+++ b/rainbowsaddle/__init__.py
@@ -103,7 +103,8 @@ class RainbowSaddle(object):
         """
         try:
             os.waitpid(pid, 0)
-        except OSError, err:
+        except OSError:
+            _, err, _ = sys.exc_info()
             if err.errno == 10:
                 while True:
                     try:
@@ -121,7 +122,7 @@ def main():
             'graceful restarts correctly')
     parser.add_argument('--pid',  help='a filename to store the '
             'rainbow-saddle PID')
-    parser.add_argument('gunicorn_args', nargs=argparse.REMAINDER, 
+    parser.add_argument('gunicorn_args', nargs=argparse.REMAINDER,
             help='gunicorn command line')
     options = parser.parse_args()
 


### PR DESCRIPTION
When in Python3, `except OSError, err:` will be syntax error.

Get the fix from here: [exception - try ... except ... as error in Python 2.5 - Python 3.x - Stack Overflow](http://stackoverflow.com/questions/11285313/try-except-as-error-in-python-2-5-python-3-x)
