### PR TITLE
run_forever method looks if gunicorn master process is running

### DIFF
--- a/rainbowsaddle/__init__.py
+++ b/rainbowsaddle/__init__.py
@@ -62,13 +62,15 @@ class RainbowSaddle(object):
     def is_running(self):
         if self.stopped:
             return False
-
-        # if gunicorn master is dead, rainbow-saddle is shutted down
-        pstatus = self.arbiter_process.status()
-        if pstatus == psutil.STATUS_ZOMBIE:
-            self.log('Gunicorn master is %s (PID: %s), shutting down '
-                     'rainbow-saddle' % (pstatus, self.arbiter_pid))
+        try:
+            pstatus = self.arbiter_process.status()
+        except psutil.NoSuchProcess:
             return False
+        else:
+            if pstatus == psutil.STATUS_ZOMBIE:
+                self.log('Gunicorn master is %s (PID: %s), shutting down '
+                    'rainbow-saddle' % (pstatus, self.arbiter_pid))
+                return False
         return True
 
     @signal_handler

--- a/rainbowsaddle/__init__.py
+++ b/rainbowsaddle/__init__.py
@@ -30,6 +30,7 @@ def signal_handler(func):
 class RainbowSaddle(object):
 
     def __init__(self, options):
+        self._arbiter_pid = None
         self.stopped = False
         # Create a temporary file for the gunicorn pid file
         fp = tempfile.NamedTemporaryFile(prefix='rainbow-saddle-gunicorn-',
@@ -45,9 +46,30 @@ class RainbowSaddle(object):
         for signum in (signal.SIGTERM, signal.SIGINT):
             signal.signal(signum, self.stop)
 
+    @property
+    def arbiter_pid(self):
+        return self._arbiter_pid
+
+    @arbiter_pid.setter
+    def arbiter_pid(self, pid):
+        self._arbiter_pid = pid
+        self.arbiter_process = psutil.Process(self.arbiter_pid)
+
     def run_forever(self):
-        while not self.stopped:
+        while self.is_running():
             time.sleep(1)
+
+    def is_running(self):
+        if self.stopped:
+            return False
+
+        # if gunicorn master is dead, rainbow-saddle is shutted down
+        pstatus = self.arbiter_process.status()
+        if pstatus != psutil.STATUS_RUNNING:
+            self.log('Gunicorn master is %s (PID: %s), shutting down '
+                     'rainbow-saddle' % (pstatus, self.arbiter_pid))
+            return False
+        return True
 
     @signal_handler
     def restart_arbiter(self, signum, frame):

--- a/rainbowsaddle/__init__.py
+++ b/rainbowsaddle/__init__.py
@@ -65,7 +65,7 @@ class RainbowSaddle(object):
 
         # if gunicorn master is dead, rainbow-saddle is shutted down
         pstatus = self.arbiter_process.status()
-        if pstatus != psutil.STATUS_RUNNING:
+        if pstatus == psutil.STATUS_ZOMBIE:
             self.log('Gunicorn master is %s (PID: %s), shutting down '
                      'rainbow-saddle' % (pstatus, self.arbiter_pid))
             return False


### PR DESCRIPTION
Gunicorn master may have died for some reason.
In these cases, rainbow-saddle dies when it detect that Gunicorn is died.

This pull request requires psutil>=2.0.0 interfaces (updated in [#3](https://github.com/flupke/rainbow-saddle/pull/3/files#diff-2eeaed663bd0d25b7e608891384b7298L13)).
It have been [changed](https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#200---2014-03-10) **.status** to **.status()** in _class Process_.
