### PR TITLE
Old master need to be turned off only after new master is ready to work

### DIFF
--- a/rainbowsaddle/__init__.py
+++ b/rainbowsaddle/__init__.py
@@ -62,11 +62,6 @@ class RainbowSaddle(object):
                 break
             time.sleep(0.3)
 
-        # Gracefully kill old workers
-        self.log('Stoping old arbiter with PID %s' % self.arbiter_pid)
-        os.kill(self.arbiter_pid, signal.SIGTERM)
-        self.wait_pid(self.arbiter_pid)
-
         # Read new arbiter PID, being super paranoid about it (we read the PID
         # file until we get the same value twice)
         prev_pid = None
@@ -84,6 +79,12 @@ class RainbowSaddle(object):
             else:
                 print('pidfile not found: ' + self.pidfile)
             time.sleep(0.3)
+
+        # Gracefully kill old workers
+        self.log('Stoping old arbiter with PID %s' % self.arbiter_pid)
+        os.kill(self.arbiter_pid, signal.SIGTERM)
+        self.wait_pid(self.arbiter_pid)
+
         self.arbiter_pid = pid
         self.log('New arbiter PID is %s' % self.arbiter_pid)
 

--- a/rainbowsaddle/__init__.py
+++ b/rainbowsaddle/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import Queue
 import os
 import os.path as op
 import sys
@@ -14,6 +13,11 @@ import functools
 import traceback
 
 import psutil
+
+try:
+    import Queue as queue
+except ImportError:
+    import queue
 
 
 def signal_handler(func):
@@ -31,7 +35,7 @@ def signal_handler(func):
 class RainbowSaddle(object):
 
     def __init__(self, options):
-        self.hup_queue = Queue.Queue()
+        self.hup_queue = queue.Queue()
         self.stopped = False
         # Create a temporary file for the gunicorn pid file
         fp = tempfile.NamedTemporaryFile(prefix='rainbow-saddle-gunicorn-',


### PR DESCRIPTION
If WSGI Application for some reason delay to start, old master is killed by rainbow-saddle before new master is ready to work.
Django Framework a example, WSGI Application is loaded, but Django is ready to work only after the first request.

To maintain graceful shutdown using USR2 signal, rainbow-saddle can keep old gunicorn master running until the new gunicorn master is ready to work.
Multiple HUP signal sequentially can be a problem in this case, so a queue was implemented to solve it, if one HUP is being processed, news HUPs will be putted in a queue and after processed HUP, the next (last) HUP will be processed in main loop.
