### PR TITLE
Use a read/write mode for the gunicorn pidfile that works in all Pythons

### DIFF
--- a/rainbowsaddle/__init__.py
+++ b/rainbowsaddle/__init__.py
@@ -40,7 +40,7 @@ class RainbowSaddle(object):
         self.stopped = False
         # Create a temporary file for the gunicorn pid file
         if options.gunicorn_pidfile:
-            fp = open(options.gunicorn_pidfile, 'wr')
+            fp = open(options.gunicorn_pidfile, 'r+')
         else:
             fp = tempfile.NamedTemporaryFile(prefix='rainbow-saddle-gunicorn-',
                 suffix='.pid', delete=False)


### PR DESCRIPTION
First of all, thanks for this project!  I'm using rainbow-saddle with Python 3 and the `--gunicorn-pidfile` option, and the `'rw'` mode used to open that file causes an error in Python 3.  Specifically, it raises `ValueError: must have exactly one of create/read/write/append mode`.  This PR changes the `open` call to use the `'r+'` mode, which opens the file for reading and writing in Python 2 and 3, ensuring that the write permissions check is still applied.
