### PR TITLE
Support gunicorn 19.6.0

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,11 @@
 News
 ====
 
+0.4.0
+-----
+
+Support new binary upgrade method used by Gunicorn, since version 19.6.0. Drops support for all previous versions of Gunicorn. See commit benoitc/gunicorn@418f140 for more info.
+
 0.3.1
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -6,16 +6,18 @@ import os
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.txt')).read()
-version = '0.3.2'
+version = '0.4.0'
 install_requires = [
     'psutil>=4.2.0',
 ]
 
 
-setup(name='rainbow-saddle',
+setup(
+    name='rainbow-saddle',
     version=version,
-    description='A wrapper around gunicorn to handle graceful restarts '
-            'correctly',
+    description=(
+        'A wrapper around gunicorn to handle graceful restarts correctly'
+    ),
     long_description=README + '\n\n' + NEWS,
     classifiers=[
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
rainbow-saddle 0.3.2 breaks with latest gunicorn version because pid is saved to a new file location since commit https://github.com/benoitc/gunicorn/commit/418f140445c050af541abeb02835c6c78b2a71f0. (And now gunicorn saves the new master pid instead of the old one).

Please note that this commit drops support for all previous versions of gunicorn. Supporting both is definitely possible, but I’m happy with supporting only the new better signal handling.
